### PR TITLE
add: Request class header and source file

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -1,0 +1,82 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Request.hpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yopark <yopark@student.42seoul.kr>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2020/09/19 16:42:22 by yopark            #+#    #+#             */
+/*   Updated: 2020/09/19 20:52:57 by yopark           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef REQUEST_HPP
+# define REQUEST_HPP
+
+# include <iostream>
+# include <string>
+# include <map>
+# include <sys/time.h>
+# include <sys/stat.h>
+# include <cstring>
+
+# include "libft.hpp"
+
+# define REQUEST_TIMEOVER 10
+
+class Connection;
+class Server;
+class Location;
+
+class Request
+{
+private:
+	enum Method { GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE };
+	enum URIType { DIRECTORY, FILE, CGI_PROGRAM };
+	enum TransferType { GENERAL, CHUNKED };
+
+	Connection *m_connection;
+	Server *m_server;
+	Location *m_location;
+	timeval m_start_at;
+
+	Method m_method;
+	std::string m_uri;
+	URIType m_uri_type;
+	std::string m_protocol;
+	std::map<std::string, std::string> m_headers;
+	TransferType m_transfer_type;
+	std::string m_content;
+	std::string m_origin;
+
+	Request();
+
+public:
+	Request(Connection *conneciton, Server *server, std::string start_line);
+	Request(const Request &x);
+	Request &operator=(const Request &x);	
+	virtual ~Request();
+
+	void add_content(std::string added_content);
+	void add_origin(std::string added_origin);
+	void add_header(std::string header);
+	bool isValidHeader(std::string header);
+	bool isOverTime();
+
+	Connection *get_m_connection() const;
+	Server *get_m_server() const;
+	Location *get_m_location() const;
+	Method get_m_method() const;
+	const std::string &get_m_uri() const;
+	URIType get_m_uri_type() const;
+	const std::string &get_m_protocol() const;
+	const std::map<std::string, std::string> &get_m_headers() const;
+	TransferType get_m_transfer_type() const;
+	const std::string &get_m_content() const;
+	const std::string &get_m_origin() const;
+};
+
+/* global operator overload */
+std::ostream &operator<<(std::ostream &out, const Request &request);
+
+#endif

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: yopark <yopark@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/19 16:42:22 by yopark            #+#    #+#             */
-/*   Updated: 2020/09/19 20:52:57 by yopark           ###   ########.fr       */
+/*   Updated: 2020/09/20 12:52:27 by yopark           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,6 +49,8 @@ private:
 	std::string m_content;
 	std::string m_origin;
 
+	std::string m_path_translated;
+
 	Request();
 
 public:
@@ -74,6 +76,7 @@ public:
 	TransferType get_m_transfer_type() const;
 	const std::string &get_m_content() const;
 	const std::string &get_m_origin() const;
+	const std::string &get_m_path_translated() const;
 };
 
 /* global operator overload */

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -1,0 +1,224 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Request.cpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yopark <yopark@student.42seoul.kr>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2020/09/19 16:42:05 by yopark            #+#    #+#             */
+/*   Updated: 2020/09/19 20:57:07 by yopark           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "Request.hpp"
+
+#include "Server.hpp"
+#include "Connection.hpp"
+#include "Location.hpp"
+
+/* ************************************************************************** */
+/* ---------------------------- STATIC VARIABLE ----------------------------- */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/* ------------------------------ CONSTRUCTOR ------------------------------- */
+/* ************************************************************************** */
+
+Request::Request(Connection *connection, Server *server, std::string start_line): m_connection(connection), m_server(server), m_transfer_type(GENERAL)
+{
+	if (gettimeofday(&m_start_at, NULL) == -1)
+		throw std::runtime_error("gettimeofday error");
+
+	std::vector<std::string> parsed = ft::split(start_line, ' ');
+	if (parsed.size() != 3) throw 400;
+	if (parsed[0] == "GET") m_method = GET;
+	else if (parsed[0] == "HEAD") m_method = HEAD;
+	else if (parsed[0] == "POST") m_method = POST;
+	else if (parsed[0] == "PUT") m_method = PUT;
+	else if (parsed[0] == "DELETE") m_method = DELETE;
+	else if (parsed[0] == "OPTIONS") m_method = OPTIONS;
+	else if (parsed[0] == "TRACE") m_method = TRACE;
+	else throw 400;
+	if (m_location->get_m_allow_method().find(parsed[0]) == m_location->get_m_allow_method().end())
+		throw 405;
+
+	if (parsed[1].length() > m_server->get_m_request_uri_limit_size())
+		throw 414;
+	m_uri = parsed[1];
+	int max_uri_match = 0;
+	for (it = m_server->get_m_locations()->begin() ; it != m_server->get_m_locations()->end() ; ++it)
+	{
+		if (std::strncmp((*it)->get_m_uri(), m_uri, (*it)->get_m_uri().length()) == 0 && (*it)->get_m_uri().length() > max_uri_match)
+		{
+			m_location = it;
+			max_uri_match = (*it)->get_m_uri().length();
+		}
+	}
+	if (!max_uri_match)
+		throw 404;	
+	std::string path(m_location->get_m_root_path() + m_uri);
+	struct stat buf;
+	stat(path.c_str(), &buf);
+	m_uri_type = FILE;
+	if (S_ISREG(buf.st_mode))
+	{
+		for (std::set<std::string>::const_iterator it = m_location->get_m_cgi().begin() ; it != m_location->get_m_cgi().end() ; ++it)
+		{
+			if (path.find(*it, path.length() - (*it).length()) != std::string::npos)
+				m_uri_type = CGI_PROGRAM;
+		}
+	}
+	else if (S_ISDIR(buf.st_mode)) m_uri_type = DIRECTORY;
+	else throw 404;
+
+	m_protocol = parsed[2];
+	if (m_protocol != "HTTP/1.1")
+		throw 505;
+}
+
+Request::Request(const Request &x)
+{
+	m_connection = x.m_connection;
+	m_server = x.m_server;
+	m_location = x.m_location;
+	m_start_at = x.m_start_at;
+
+	m_method = x.m_method;
+	m_uri = x.m_uri;
+	m_uri_type = x.m_uri_type;
+	m_protocol = x.m_protocol;
+	m_headers = x.m_headers;
+	m_transfer_type = x.m_transfer_type;
+	m_content = x.m_content;
+	m_origin = x.m_origin;
+}
+
+/* ************************************************************************** */
+/* ------------------------------- DESTRUCTOR ------------------------------- */
+/* ************************************************************************** */
+
+Request::~Request()
+{
+
+}
+
+/* ************************************************************************** */
+/* -------------------------------- OVERLOAD -------------------------------- */
+/* ************************************************************************** */
+
+Request &Request::operator=(const Request &x)
+{
+	if (this == &x)
+		return (*this);
+
+	m_connection = x.m_connection;
+	m_server = x.m_server;
+	m_location = x.m_location;
+	m_start_at = x.m_start_at;
+
+	m_method = x.m_method;
+	m_uri = x.m_uri;
+	m_uri_type = x.m_uri_type;
+	m_protocol = x.m_protocol;
+	m_headers = x.m_headers;
+	m_transfer_type = x.m_transfer_type;
+	m_content = x.m_content;
+	m_origin = x.m_origin;
+
+	return (*this);
+}
+
+std::ostream &operator<<(std::ostream &out, const Request &request)
+{
+	out << "METHOD: " << request.get_m_method() << " (GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE)" << std::endl;
+	out << "URI: " << request.get_m_uri() << std::endl;
+	out << "URI_TYPE: " << request.get_m_uri_type() << " (DIRECTORY, FILE, CGI_PROGRAM)" << std::endl;
+	out << "PROTOCOL: " << request.get_m_protocol() << std::endl;
+	out << "HEADERS:" << std::endl;
+	for (std::map<std::string, std::string>::const_iterator it = request.get_m_headers().begin() ; it != request.get_m_headers().end() ; ++it) // mapToString
+		out << "KEY: " << (*it).first << ", " << "VALUE: " << (*it).second << std::endl;
+	out << "TRANSFER_TYPE: " << request.get_m_transfer_type() << " (GENERAL, CHUNKED)" << std::endl;
+	out << "CONTENT: " << request.get_m_content() << std::endl;
+	out << "ORIGIN: " << request.get_m_origin() << std::endl;
+	return (out);
+}
+
+/* ************************************************************************** */
+/* --------------------------------- GETTER --------------------------------- */
+/* ************************************************************************** */
+
+Connection				*Request::get_m_connection() const { return (m_connection); }
+Server					*Request::get_m_server() const { return (m_server); }
+Location				*Request::get_m_location() const { return (m_location); }
+Request::Method			Request::get_m_method() const { return (m_method); }
+const std::string		&Request::get_m_uri() const { return (m_uri); }
+Request::URIType		Request::get_m_uri_type() const { return (m_uri_type); }
+const std::string		&Request::get_m_protocol() const { return (m_protocol); }
+const std::map<std::string, std::string> &Request::get_m_headers() const { return (m_headers); }
+Request::TransferType	Request::get_m_transfer_type() const { return (m_transfer_type); }
+const std::string		&Request::get_m_content() const { return (m_content); }
+const std::string		&Request::get_m_origin() const { return (m_origin); }
+
+/* ************************************************************************** */
+/* --------------------------------- SETTER --------------------------------- */
+/* ************************************************************************** */
+
+void Request::add_content(std::string added_content)
+{
+	m_content.append(added_content);
+}
+
+void Request::add_origin(std::string added_origin)
+{
+	m_origin.append(added_origin);
+}
+
+
+void Request::add_header(std::string header)
+{
+	size_t pos = header.find(':');
+	std::string key = header.substr(0, pos);
+	std::string value = header.substr(pos + 1);
+	key = ft::trim(key);
+	value = ft::trim(value);
+	for (size_t i = 0 ; i < key.length() ; ++i) // capitalize
+		key[i] = (i == 0 || key[i - 1] == '-') ? std::toupper(key[i]) : std::tolower(key[i]);
+
+	if (key == "Content-Type" && value == "chunked")
+		m_transfer_type = CHUNKED;
+	if (key == "Content-Length" && std::atoi(value.c_str()) > m_server->get_m_limit_client_body_size())
+		throw 413;
+	std::pair<std::map<std::string, std::string>::iterator, bool> ret = m_headers.insert(std::make_pair(key, value));
+	if (!ret.second)
+		throw 400;
+}
+
+/* ************************************************************************** */
+/* ------------------------------- EXCEPTION -------------------------------- */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/* ---------------------------- MEMBER FUNCTION ----------------------------- */
+/* ************************************************************************** */
+
+bool Request::isValidHeader(std::string header)
+{
+	if (header.size() > m_server->get_m_request_header_limit_size())
+		throw 400;
+	if (header.find(':') == std::string::npos)
+		return (false);
+	return (true);
+}
+
+bool Request::isOverTime()
+{
+	timeval now;
+
+	if (gettimeofday(&now, NULL) == -1)
+		throw std::runtime_error("gettimeofday error");
+	
+	long now_nbr = now.tv_sec * 1000 + now.tv_usec;
+	long start_nbr = m_start_at.tv_sec * 1000 + m_start_at.tv_usec;
+	
+	return ((now_nbr - start_nbr) / 1000 >= REQUEST_TIMEOVER);
+}

--- a/test/Request_test.cpp
+++ b/test/Request_test.cpp
@@ -1,0 +1,14 @@
+#include "../includes/Request.hpp"
+#include <iostream>
+
+int main(void)
+{
+	Request a(NULL, NULL, "HEAD /Users/yopark HTTP/1.1");
+
+	a.add_header("cONtent-tYpe   :     chunked");
+	a.add_content("<!DOCTYPE html>\r\n");
+	a.add_content("<body></body>\r\n");
+
+	std::cout << a << std::endl;
+	return (0);
+}


### PR DESCRIPTION
아직 Server class가 만들어지지 않아 Server class에 저장되어 있는 변수를 통한 테스트는 정확히 진행하지 못했습니다. 

* 들어온 m_uri 중 가장 길게 location->m_uri와 일치하는 곳으로 location을 지정합니다. 
* header로 들어온 key는 자동으로 capitalize합니다. 하지만 value는 정확한 기준을 알지 못하여 좌우 공백 trim만 진행합니다. 
* value로 여러 값이 들어올 수 있으므로 이후에 value를 다시 set으로 지정해야 할 것 같습니다. 현재는 value로 하나만을 받을 수 있습니다. 
* add_content와 add_origin의 경우 tester를 보시면 알 수 있듯이 단순 append만 진행하도록 하였습니다. 
* 에러 코드의 경우 throw 404 와 같이 단순 int형을 보내 catch(int status); 로 받을 수 있도록 만들었습니다. 