### PR TITLE
Server request

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Request.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: eunhkim <eunhkim@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jujeong <jujeong@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/19 16:42:22 by yopark            #+#    #+#             */
-/*   Updated: 2020/09/21 21:34:26 by eunhkim          ###   ########.fr       */
+/*   Updated: 2020/09/22 15:02:03 by jujeong          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,12 +54,12 @@ public:
 	Request();
 	Request(Connection *conneciton, Server *server, std::string start_line);
 	Request(const Request &x);
-	Request &operator=(const Request &x);	
+	Request &operator=(const Request &x);
 	virtual ~Request();
 
 	void add_content(std::string added_content);
 	void add_origin(std::string added_origin);
-	void add_header(std::string header);
+	void add_header(std::string key, std::string value);
 	bool isValidHeader(std::string header);
 	bool isOverTime();
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -4,6 +4,7 @@
 # include <string>
 # include <iostream>
 # include <map>
+# include <set>
 # include <vector>
 # include <queue>
 # include <sys/socket.h>
@@ -21,13 +22,6 @@
 
 # define SEND_RESPONSE_AT_ONCE 5
 # define RESPONSE_OVERLOAD_COUNT 20
-
-# include <vector>
-# include <set>
-# include <map>
-# include "Location.hpp"
-# include "Request.hpp"
-# include "libft.hpp"
 
 class Server
 {
@@ -89,10 +83,10 @@ class Server
 		// int isSendable(int client_fd);
 		// int sendResponse(Response response);
 
-		// bool hasRequest(int client_fd);
-		// Request recvRequest(int client_fd);
+		bool hasRequest(int client_fd);
+		Request recvRequest(int client_fd, Connection connection);
 
-		void solveRequest(const Request& request);		
+		void solveRequest(const Request& request);
 		// void executeAutoindex(const Request& request);
 		// int executeGet(Request request);
 		// int executeHead(Request request);
@@ -104,7 +98,7 @@ class Server
 
 		// char** createCGIEnv(Request request);
 		// int executeCGI(Request request);
-		
+
 		// int createResponse(int status);
 };
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Request.cpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: eunhkim <eunhkim@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jujeong <jujeong@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/09/19 16:42:05 by yopark            #+#    #+#             */
-/*   Updated: 2020/09/21 21:38:44 by eunhkim          ###   ########.fr       */
+/*   Updated: 2020/09/22 15:02:07 by jujeong          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -203,20 +203,20 @@ void Request::add_origin(std::string added_origin)
 }
 
 
-void Request::add_header(std::string header)
+void Request::add_header(std::string key, std::string value)
 {
-	size_t pos = header.find(':');
-	std::string key = header.substr(0, pos);
-	std::string value = header.substr(pos + 1);
-	key = ft::trim(key);
-	value = ft::trim(value);
-	for (size_t i = 0 ; i < key.length() ; ++i) // capitalize
-		key[i] = (i == 0 || key[i - 1] == '-') ? std::toupper(key[i]) : std::tolower(key[i]);
+	// size_t pos = header.find(':');
+	// std::string key = header.substr(0, pos);
+	// std::string value = header.substr(pos + 1);
+	// key = ft::trim(key);
+	// value = ft::trim(value);
+	// for (size_t i = 0 ; i < key.length() ; ++i) // capitalize
+	// 	key[i] = (i == 0 || key[i - 1] == '-') ? std::toupper(key[i]) : std::tolower(key[i]);
 
-	if (key == "Content-Type" && value == "chunked")
-		m_transfer_type = CHUNKED;
-	if (key == "Content-Length" && std::atoi(value.c_str()) > m_server->get_m_limit_client_body_size())
-		throw 413;
+	// if (key == "Content-Type" && value == "chunked")
+	// 	m_transfer_type = CHUNKED;
+	// if (key == "Content-Length" && std::atoi(value.c_str()) > m_server->get_m_limit_client_body_size())
+	// 	throw 413;
 	std::pair<std::map<std::string, std::string>::iterator, bool> ret = m_headers.insert(std::make_pair(key, value));
 	if (!ret.second)
 		throw 400;
@@ -245,9 +245,9 @@ bool Request::isOverTime()
 
 	if (gettimeofday(&now, NULL) == -1)
 		throw std::runtime_error("gettimeofday error");
-	
+
 	long now_nbr = now.tv_sec * 1000 + now.tv_usec;
 	long start_nbr = m_start_at.tv_sec * 1000 + m_start_at.tv_usec;
-	
+
 	return ((now_nbr - start_nbr) / 1000 >= REQUEST_TIMEOVER);
 }


### PR DESCRIPTION
Server::hasRequest(), Server::recvRequest() 메소드를 작성하였습니다.

- dup2() 를 이용하여 std::cin 을 client_fd 로 복사하였고 std::getline 함수를 이용하여 헤더까지는 라인 단위로 읽어서 저장했습니다.

- 이후 post나 put 메소드이면 1024 바이트의 고정 배열을 사용하여 read() 를 하였고 버퍼가 비었다는 리턴 결과인 -1이 반환될 때 까지 읽어서 저장하였고 content-length 보다 길거나 짧은 경우는 에러 처리를 하지 않았습니다.

- 기존의 Request 생성자에서 실행하던 코드를 조금 옮겨와 recvRequest() 에서 실행하도록 하였습니다.