### PR TITLE
Fix 241005

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -101,6 +101,7 @@ class Server
 		void writeDetectNewRequestLog(const Connection& connection);
 		void writeCreateNewRequestLog(const Request& request);
 		void reportCreateNewRequestLog(const Connection& connection, int status);
+		void writeCreateNewResponseLog(const Response& response);
 };
 
 /* global operator overload */

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -79,7 +79,7 @@ class Server
 		void sendResponse(Response response);
 
 		bool hasRequest(int client_fd);
-		Request recvRequest(int client_fd, Connection connection);
+		Request recvRequest(int client_fd, Connection* connection);
 
 		void solveRequest(const Request& request);
 		void executeAutoindex(const Request& request);

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -12,6 +12,7 @@ class ServerManager
 		static int access_fd;
 	private:
 		std::vector<Server> m_servers;
+		std::set<int> m_server_fdset;
         Config m_config;
         int m_max_fd;
         fd_set m_read_set;
@@ -35,6 +36,7 @@ class ServerManager
 
 		/* getter & setter function */
 		const std::vector<Server>& get_m_servers() const;
+		const std::set<int>& get_m_server_fdset() const;
 		Config get_m_config() const;
 		int get_m_max_fd() const;
 		void set_m_max_fd(int max_fd);

--- a/log/access.log
+++ b/log/access.log
@@ -1,0 +1,19 @@
+
+[Created][Servers]1 servers created successfully.
+[HealthCheck][Server][Max_fd:5][Connection:5][Response:]
+[HealthCheck][Server][Max_fd:5][Connection:5][Response:]
+[Detected][Connection][Server:default][Host:127.0.0.1] New connection detected.
+[Created][Connection][Server:default][CFD:6][IP:127.0.0.1][Port:33753]
+[HealthCheck][Server][Max_fd:6][Connection:5,6][Response:]
+[Detected][Connection][Server:default][Host:127.0.0.1] New connection detected.
+[Created][Connection][Server:default][CFD:7][IP:127.0.0.1][Port:34009]
+[HealthCheck][Server][Max_fd:7][Connection:5,6,7][Response:]
+[Detected][Request][Server:default][CIP:127.0.0.1][CFD:6] New request detected.
+[Created][Request][Server:default][Method:GET][URI:/][Path:/Users/gim-eunhyul/42seoul/subject/webserv/config/www/][Query:] New request created.
+[Created][Response][Server:default][200][OK][CFD:6][headers:4][body2585] New response created.
+[HealthCheck][Server][Max_fd:7][Connection:5,6,7][Response:6]
+[HealthCheck][Server][Max_fd:7][Connection:5,6,7][Response:6]
+[HealthCheck][Server][Max_fd:7][Connection:5,6,7][Response:]
+[Detected][Request][Server:default][CIP:127.0.0.1][CFD:6] New request detected.
+[Created][Response][Server:default][404][Not Found][CFD:6][headers:4][body621] New response created.
+[Failed][Request][Server:default][CIP:127.0.0.1][CFD:6][404] Failed to create new connection.

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1023,6 +1023,7 @@ Server::createResponse(Connection* connection, int status, HEADERS headers, std:
 	}
 	writeCreateNewResponseLog(response);
 	m_responses.push(response);
+	m_manager->fdSet(response.get_m_connection()->get_m_client_fd(), ServerManager::WRITE_SET);
 }
 
 /* ************************************************************************** */

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -375,7 +375,7 @@ Server::run()
 		else if (hasRequest(fd))	{
 			writeDetectNewRequestLog(it2->second);
 			try {
-				request = recvRequest(fd, it2->second);
+				request = recvRequest(fd, &it2->second);
 			} catch (int status_code) {
 				createResponse(&(it2->second), status_code);
 				reportCreateNewRequestLog(it2->second, status_code);
@@ -946,7 +946,7 @@ namespace {
 	}
 }
 
-Request Server::recvRequest(int client_fd, Connection connection)
+Request Server::recvRequest(int client_fd, Connection* connection)
 {
 	std::string start_line;
 	Request::TransferType transfer_type = Request::GENERAL;
@@ -956,7 +956,7 @@ Request Server::recvRequest(int client_fd, Connection connection)
 	std::getline(std::cin, start_line);
 	std::string origin_message = start_line + "\n";
 	start_line = ft::rtrim(start_line, "\r");
-	Request request(&connection, this, start_line);
+	Request request(connection, this, start_line);
 	if (!headerParsing(this, request, origin_message, transfer_type, content_length))
 		throw 400;
 	std::string message_body = readBodyMessage(this, request, origin_message, transfer_type, content_length, client_fd);
@@ -1093,8 +1093,9 @@ void
 Server::writeCreateNewResponseLog(const Response& response)
 {
 	std::string text = "[Created][Response][Server:" + m_server_name + "][" \
-	+ std::to_string(response.get_m_status_code()) + "][" + response.get_m_status_description() + "][headers:" \
-	+ response.get_m_headers().size() + "][body" + response.get_m_content().size();
+	+ std::to_string(response.get_m_status_code()) + "][" + response.get_m_status_description() + "][CFD:" \
+	+ std::to_string(response.get_m_connection()->get_m_client_fd()) + "][headers:" \
+	+ std::to_string(response.get_m_headers().size()) + "][body" + std::to_string(response.get_m_content().size()) + "]";
 	text.append(" New response created.\n");
 	ft::log(ServerManager::access_fd, text);
 	return ;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -378,7 +378,7 @@ Server::run()
 				request = recvRequest(fd, it2->second);
 			} catch (int status_code) {
 				createResponse(&(it2->second), status_code);
-				reportCreateNewRequestLog(it2->second, status);
+				reportCreateNewRequestLog(it2->second, status_code);
 				continue ;
 			} catch (std::exception& e) {
 				createResponse(&(it2->second), 500);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1021,6 +1021,7 @@ Server::createResponse(Connection* connection, int status, HEADERS headers, std:
 		std::string value = (*it).substr((*it).find(":") + 1);
 		response.addHeader(key, value);
 	}
+	writeCreateNewResponseLog(response);
 	m_responses.push(response);
 }
 
@@ -1083,6 +1084,17 @@ Server::reportCreateNewRequestLog(const Connection& connection, int status)
 	std::string text = "[Failed][Request][Server:" + m_server_name + "][CIP:"
 	+ connection.get_m_client_ip() + "][CFD:" + std::to_string(connection.get_m_client_fd()) + "]["
 	+ std::to_string(status) + "] Failed to create new connection.\n";
+	ft::log(ServerManager::access_fd, text);
+	return ;
+}
+
+void
+Server::writeCreateNewResponseLog(const Response& response)
+{
+	std::string text = "[Created][Response][Server:" + m_server_name + "][" \
+	+ std::to_string(response.get_m_status_code()) + "][" + response.get_m_status_description() + "][headers:" \
+	+ response.get_m_headers().size() + "][body" + response.get_m_content().size();
+	text.append(" New response created.\n");
 	ft::log(ServerManager::access_fd, text);
 	return ;
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -61,6 +61,7 @@ operator<<(std::ostream& out, const ServerManager&) {
 /* ************************************************************************** */
 
 const std::vector<Server>& ServerManager::get_m_servers() const { return (this->m_servers); }
+const std::set<int>& ServerManager::get_m_server_fdset() const { return (this->m_server_fdset); }
 Config ServerManager::get_m_config() const { return (this->m_config); }
 int ServerManager::get_m_max_fd() const { return (this->m_max_fd); }
 
@@ -437,6 +438,7 @@ ServerManager::createServer(const std::string& configuration_file_path, char **e
 				+ "-" + std::to_string(j) + ") is not valid."));
 		}
 		m_servers.push_back(Server(this, server_block, location_blocks, &this->m_config));
+		m_server_fdset.insert(m_servers.back().get_m_fd());
 	}
 	writeCreateServerLog();
 }
@@ -486,7 +488,7 @@ ServerManager::runServer()
 			while (it2 != it->get_m_connections().end())
 			{
 				int fd = it2->first;
-				if (fd != it->get_m_fd() && it2->second.isOverTime())
+				if (!ft::hasKey(m_server_fdset, fd) && it2->second.isOverTime())
 					it->closeConnection(fd);
 				++it2;
 			}

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -480,6 +480,7 @@ ServerManager::runServer()
 		{
 			continue ;
 		}
+		writeServerHealthLog(true);
 		for (std::vector<Server>::iterator it = m_servers.begin() ; it != m_servers.end() ; ++it)
 		{	
 			it->run();


### PR DESCRIPTION
* isOverTime에서 서버 fd를 제외시킬 수 있도록, ServerManager에 m_server_fdset 변수를 추가했습니다.
* response를 생성한 후에 write set에 등록이 안 되고 있어서 manager->fdSet 함수를 호출하는 코드를 추가했습니다.
* recvRequest에서 지역변수 Conneciton의 주소를 포인터 인자로 넘겨주고 있어서(넘겨준 후 객체 소멸, 데이터 초기화), 처음부터 포인터를 받는 방식으로 변경했습니다.