### PR TITLE
Fix: arrange run function of server class

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -32,6 +32,8 @@ class Server
 	private:
 		void basic_decode(std::string data, std::string& key, std::string& value);
 		std::string inet_ntoa(unsigned int address);
+		void runSend();
+		bool runRecvAndSolve(std::map<int, Connection>::iterator it);
 		std::string getExtension(std::string path);
 		std::string getMimeTypeHeader(std::string path);
 		time_t getLastModified(std::string path);

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -28,6 +28,8 @@ class ServerManager
         bool isValidConfigBlock(std::string& config_block);
         bool isValidServerBlock(std::string& server_block);
         bool isValidLocationBlock(std::string& location_block);
+		void copyFdSet();
+		void closeOldConnection(std::vector<Server>::iterator it);
 	public:
 		ServerManager();
 		ServerManager(const ServerManager&);


### PR DESCRIPTION
아래의 작업들을 진행했습니다. 현재 autoindex 응답, 에러 응답을 1회까지는 정상적으로 처리합니다. 해당 경우에도 살아있는 커넥션에 대한 연속적인 리퀘스트 성공 응답(autoindex 2회 연속 요청)은 진행되지 않고 있습니다.

* run server가 복잡해서 함수 분리를 진행했습니다.
* error_set은 따로 존재할 필요가 없고 read_set을 그대로 쓰면 되기 때문에(연결된 커넥션에 문제가 생겼는지를 확인하는 것이므로) read_set에서 error_copy_set으로 복사하는 것으로 변경했습니다.
* connection을 닫을 때 write_set에서 fdClear를 처리하고, send를 할 때에도 readSet으로부터 연결된 커넥션인지를 한 번 더 확인하도록 안전하게 바꾸었습니다.
